### PR TITLE
Fixed Message Mixing/ appending issue

### DIFF
--- a/src/client_code/client.c
+++ b/src/client_code/client.c
@@ -257,6 +257,7 @@ void sendTcpAddress(struct sockaddr_in serverAddress, struct sockaddr_in tcpAddr
 // Function to receive messages from the server
 void receiveMessageFromServer() {
     char buffer[USER_INPUT_BUFFER_LENGTH];
+    memset(buffer, 0, sizeof(buffer));  // Clear the buffer before receiving a new message
     int bytesReceived = recvfrom(udpSocketDescriptor, buffer, USER_INPUT_BUFFER_LENGTH, 0, NULL, NULL);
     if (bytesReceived > 0) {
         buffer[bytesReceived] = '\0';  // Null-terminate the received string

--- a/src/common/network_node.c
+++ b/src/common/network_node.c
@@ -308,7 +308,7 @@ int checkUdpSocket(int listeningUDPSocketDescriptor, struct sockaddr_in* incomin
   }
   else if (checkStringForCommand(message) == 0) { // Message is plain text
     printf("Received plain text\n");
-    return 2;                                     // return 2
+    return bytesReceived;                                     // return 2
   }
   else if (strncmp(message, "%put ", 5) == 0) {   // Received put command
     printf("Received put command\n"); 

--- a/src/server_code/server.h
+++ b/src/server_code/server.h
@@ -20,6 +20,6 @@ int findEmptyConnectedClient(uint8_t);
 
 void printAllConnectedClients();
 
-void broadcastMessage(int, char*, struct sockaddr_in*);
+void broadcastMessage(int udpSocketDescriptor, char* message, struct sockaddr_in* sender_addr, int message_length);
 
 #endif


### PR DESCRIPTION
Fixed issue with messages sharing the buffer and mixing past and present messages now all messages are correctly delivered to all clients except the sending client. There is still a bug that messages won't send that are under 5 characters and it will crash the server with a UDP parameter error. This is because the buffer is too small for the smaller messages. We need to add padding of some sort to get it to be at least 5 characters.